### PR TITLE
docs(search-client): update deprecation notice

### DIFF
--- a/packages/search/projects/search-lib/README.md
+++ b/packages/search/projects/search-lib/README.md
@@ -4,7 +4,7 @@ An Angular module that exports a component that can enable users to search over 
 
 ### Deprecation Notice
 
-Search-client now supports angular v14, we will provide support for the older version that is based on angular v13 till 30th June 2024.
+Search-client now supports Angular v17, we will provide support for the older version that is based on Angular v14 till 30th August 2025 .
 
 ## Angular Module
 

--- a/packages/search/projects/search-lib/package.json
+++ b/packages/search/projects/search-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sourceloop/search-client",
   "version": "7.0.0",
-  "description": "A global search component for search microservice. ",
+  "description": "A global search component for search microservice.",
   "peerDependencies": {
     "@angular/animations": "^17.3.0",
     "@angular/cdk": "^17.3.0",


### PR DESCRIPTION
GH-36

Update the deprecation notice to reflect the latest changes. The current deprecation message was outdated.


